### PR TITLE
Add intended RapidJSON monotonic buffer allocation

### DIFF
--- a/PMR/json_tests.cpp
+++ b/PMR/json_tests.cpp
@@ -260,7 +260,7 @@ static void RapidJSON_PMR_Monotonic_Winkout_Parse(benchmark::State &state, std::
 }
 
 
-static void RapidJSON_Monotonic_Winkout_Parse(benchmark::State &state, std::string_view s)
+static void RapidJSON_Monotonic_Parse(benchmark::State &state, std::string_view s)
 {
   for (auto _ : state) {
     using namespace rapidjson;
@@ -312,7 +312,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "citm_catalog.json");
-ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "citm_catalog.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Parse, "citm_catalog.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "citm_catalog.json");
 
 ADD_BENCHMARK(Boost_JSON_Default_Parse, "gsoc-2018.json");
@@ -324,7 +324,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "gsoc-2018.json");
-ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "gsoc-2018.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "gsoc-2018.json");
 
 ADD_BENCHMARK(Boost_JSON_Default_Parse, "github_events.json");
@@ -336,7 +336,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "github_events.json");
-ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "github_events.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Parse, "github_events.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "github_events.json");
 
 

--- a/PMR/json_tests.cpp
+++ b/PMR/json_tests.cpp
@@ -259,6 +259,17 @@ static void RapidJSON_PMR_Monotonic_Winkout_Parse(benchmark::State &state, std::
   }
 }
 
+
+static void RapidJSON_Monotonic_Winkout_Parse(benchmark::State &state, std::string_view s)
+{
+  for (auto _ : state) {
+    using namespace rapidjson;
+    std::string monotonic_buffer{s};
+    rapidjson::Document d;
+    d.ParseInsitu(monotonic_buffer.data());
+  }
+}
+
 static void RapidJSON_CRT_Parse(benchmark::State &state, std::string_view s)
 {
   for (auto _ : state) {
@@ -301,6 +312,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "citm_catalog.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "citm_catalog.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "citm_catalog.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "citm_catalog.json");
 
 ADD_BENCHMARK(Boost_JSON_Default_Parse, "gsoc-2018.json");
@@ -312,6 +324,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "gsoc-2018.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "gsoc-2018.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "gsoc-2018.json");
 
 ADD_BENCHMARK(Boost_JSON_Default_Parse, "github_events.json");
@@ -323,6 +336,7 @@ ADD_BENCHMARK(RapidJSON_PMR_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Pool_Monotonic_Parse, "github_events.json");
 ADD_BENCHMARK(RapidJSON_PMR_Monotonic_Winkout_Parse, "github_events.json");
+ADD_BENCHMARK(RapidJSON_Monotonic_Winkout_Parse, "github_events.json");
 ADD_BENCHMARK(nlohmann_JSON_Default, "github_events.json");
 
 


### PR DESCRIPTION
RapidJSON was made without pmr allocators in mind, obviously. But RapidJSON has an intended monotonic buffer method of allocation method, [ParseInsitu](https://rapidjson.org/md_doc_dom.html#InSituParsing). This leads to a big speedup, but removes the ability to do DOM manipulation safely (you would be modifying the given buffer, which could lead to overflows or overwriting data of other parts of the DOM).

Running the added benchmark leads to the following results:
```
$ ../build/bin/json_pmr_performance_tests
2020-12-29T11:10:29+01:00
Running ../build/bin/json_pmr_performance_tests
Run on (24 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x12)
  L1 Instruction 32 KiB (x12)
  L2 Unified 512 KiB (x12)
  L3 Unified 16384 KiB (x4)
Load Average: 0.62, 0.94, 0.70
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
--------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------
JSON_Perf/Boost_JSON_Default_Parse-"citm_catalog.json"                   2432229 ns      2431063 ns          289 bytes_per_second=677.56M/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Winkout_Parse-"citm_catalog.json"     1376824 ns      1376163 ns          508 bytes_per_second=1.16889G/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Parse-"citm_catalog.json"             1439693 ns      1439101 ns          481 bytes_per_second=1.11777G/s
JSON_Perf/Boost_JSON_PMR_Pool_Monotonic_Parse-"citm_catalog.json"        2524916 ns      2523705 ns          276 bytes_per_second=652.687M/s
JSON_Perf/RapidJSON_Default_Parse-"citm_catalog.json"                    1512186 ns      1511517 ns          461 bytes_per_second=1089.76M/s
JSON_Perf/RapidJSON_CRT_Parse-"citm_catalog.json"                        2067777 ns      2066741 ns          339 bytes_per_second=796.999M/s
JSON_Perf/RapidJSON_PMR_Parse-"citm_catalog.json"                        2209024 ns      2208053 ns          317 bytes_per_second=745.992M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Parse-"citm_catalog.json"              1679132 ns      1678325 ns          416 bytes_per_second=981.449M/s
JSON_Perf/RapidJSON_PMR_Pool_Monotonic_Parse-"citm_catalog.json"         2043373 ns      2042495 ns          341 bytes_per_second=806.46M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Winkout_Parse-"citm_catalog.json"      1519011 ns      1518384 ns          460 bytes_per_second=1084.83M/s
JSON_Perf/RapidJSON_Monotonic_Winkout_Parse-"citm_catalog.json"          1123903 ns      1123412 ns          624 bytes_per_second=1.43187G/s
JSON_Perf/nlohmann_JSON_Default-"citm_catalog.json"                      9920401 ns      9915934 ns           71 bytes_per_second=166.115M/s
JSON_Perf/Boost_JSON_Default_Parse-"gsoc-2018.json"                      5325597 ns      5322922 ns          133 bytes_per_second=596.226M/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Winkout_Parse-"gsoc-2018.json"        4017734 ns      4015819 ns          172 bytes_per_second=790.291M/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Parse-"gsoc-2018.json"                4097893 ns      4096090 ns          170 bytes_per_second=774.804M/s
JSON_Perf/RapidJSON_Default_Parse-"gsoc-2018.json"                       7111341 ns      7108229 ns           98 bytes_per_second=446.478M/s
JSON_Perf/RapidJSON_CRT_Parse-"gsoc-2018.json"                           7707543 ns      7704114 ns           90 bytes_per_second=411.944M/s
JSON_Perf/RapidJSON_PMR_Parse-"gsoc-2018.json"                           7925690 ns      7922166 ns           88 bytes_per_second=400.606M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Parse-"gsoc-2018.json"                 7216015 ns      7213023 ns           96 bytes_per_second=439.991M/s
JSON_Perf/RapidJSON_PMR_Pool_Monotonic_Parse-"gsoc-2018.json"            7679203 ns      7675818 ns           91 bytes_per_second=413.463M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Winkout_Parse-"gsoc-2018.json"         7160713 ns      7157743 ns           98 bytes_per_second=443.389M/s
JSON_Perf/RapidJSON_Monotonic_Winkout_Parse-"gsoc-2018.json"             1251186 ns      1250599 ns          564 bytes_per_second=2.47824G/s
JSON_Perf/nlohmann_JSON_Default-"gsoc-2018.json"                        18272788 ns     18264004 ns           39 bytes_per_second=173.766M/s
JSON_Perf/Boost_JSON_Default_Parse-"github_events.json"                   153927 ns       153854 ns         4550 bytes_per_second=403.726M/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Winkout_Parse-"github_events.json"      77513 ns        77473 ns         9042 bytes_per_second=801.758M/s
JSON_Perf/Boost_JSON_PMR_Monotonic_Parse-"github_events.json"              82103 ns        82068 ns         8407 bytes_per_second=756.872M/s
JSON_Perf/RapidJSON_Default_Parse-"github_events.json"                    140807 ns       140757 ns         4957 bytes_per_second=441.291M/s
JSON_Perf/RapidJSON_CRT_Parse-"github_events.json"                        173647 ns       173577 ns         4034 bytes_per_second=357.851M/s
JSON_Perf/RapidJSON_PMR_Parse-"github_events.json"                        189692 ns       189612 ns         3687 bytes_per_second=327.588M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Parse-"github_events.json"              148031 ns       147978 ns         4715 bytes_per_second=419.755M/s
JSON_Perf/RapidJSON_PMR_Pool_Monotonic_Parse-"github_events.json"         172133 ns       172069 ns         4050 bytes_per_second=360.988M/s
JSON_Perf/RapidJSON_PMR_Monotonic_Winkout_Parse-"github_events.json"      142153 ns       142098 ns         4907 bytes_per_second=437.126M/s
JSON_Perf/RapidJSON_Monotonic_Winkout_Parse-"github_events.json"           50172 ns        50155 ns        13653 bytes_per_second=1.20944G/s
JSON_Perf/nlohmann_JSON_Default-"github_events.json"                      511174 ns       510939 ns         1368 bytes_per_second=121.57M/s
```

1.43187G/s, 2.47824G/s and 1.20944G/s respectively.