### PR TITLE
Homework: Add nfa2dfa_auto_all_the_things.

### DIFF
--- a/homework/NFA2DFA_auto_all_the_things/FA.cpp
+++ b/homework/NFA2DFA_auto_all_the_things/FA.cpp
@@ -1,0 +1,50 @@
+#include "FA.h"
+using namespace fa;
+
+/*Constructor of class finite_autometa.  */
+finite_autometa::finite_autometa (const std::set <state> states,
+				  const std::set <symbol> input_alpha,
+				  const std::set <state> final_states,
+				  const state initial_state,
+				  transition_table relations)
+  :m_Q (states), m_input (input_alpha), m_F (final_states), m_q0 (initial_state), m_tr (relations)
+{
+  //TODO: check if it's an DFA or not and set is_dfa accordingly
+}
+
+/*Function to move from one state to another based on the trasition relation
+  defined by the autometa and return the set of new states the autometa can move
+  to and return empty set in case the transition relation doesn't exist.  */
+std::set <state>
+finite_autometa::move (state current_state, symbol input_symbol) const
+{
+  auto new_state = m_tr.find({current_state, input_symbol});
+
+  if (new_state != m_tr.end ())
+    {
+      return (new_state->second);
+    }
+
+  return {};
+}
+
+
+/*Function to move from a set of states to another based on the trasition
+  relation defined by the autometa and return the set of new states the autometa
+  can move to and return empty set in case the transition relation doesn't
+  exist.  */
+std::set <state>
+finite_autometa::move (std::set<state> states, symbol input_symbol) const
+{
+  std::set <state> destination_set;
+  for (auto current_state: states)
+    {
+      auto new_states = move (current_state, input_symbol);
+
+      for (auto dest_state: new_states)
+	{
+	  destination_set.insert (dest_state);
+	}
+    }
+  return destination_set;
+}

--- a/homework/NFA2DFA_auto_all_the_things/FA.h
+++ b/homework/NFA2DFA_auto_all_the_things/FA.h
@@ -1,0 +1,52 @@
+#include <map>
+#include <set>
+#include <utility>
+
+namespace fa
+{
+
+constexpr auto epsilon = 0;
+using state = int;
+using symbol = char;
+
+/* Each STATE on scanning a symbol maps to a set of states.  */
+using transition_table =  std::map <std::pair <state, symbol>,
+				    std::set <state>>;
+
+/* A finite autometa is a 5 tupple ( Q, sigma, delta, F, q0 ).  */
+class finite_autometa
+{
+ public:
+
+  finite_autometa (const std::set <state> states,
+		   const std::set <symbol> input_alpha,
+  		   const std::set <state> final_states,
+		   const state initial_state,
+		   transition_table relations);
+
+  finite_autometa();
+
+  auto move (state current_state, symbol scanned_symbol) const -> std::set <state>;
+  auto move (std::set <state> states, symbol scanned_symbol) const -> std::set <state>;
+
+  //TODO: maybe a function to check sanity of the autometa.
+
+  // Accessors
+  auto get_states () const {return m_Q;};
+  auto get_input_chars () const {return m_input;};
+  auto get_finalstates () const {return m_F;};
+  auto get_initialstate () const {return m_q0;};
+  auto get_transition_relations () const
+  { return m_tr; };
+
+ private:
+
+  bool m_is_DFA;
+  const std::set <state> m_Q;
+  const std::set <symbol> m_input;
+  const std::set <state> m_F;
+  const state m_q0;
+  const transition_table m_tr;
+};
+
+} // namespace fa

--- a/homework/NFA2DFA_auto_all_the_things/Makefile
+++ b/homework/NFA2DFA_auto_all_the_things/Makefile
@@ -1,0 +1,21 @@
+CXX=g++
+CXXFLAGS=-std=c++17
+RM=rm -f
+
+SRCS=FA.cpp convertor.cpp
+OBJS=$(subst .cpp,.o,$(SRCS))
+
+all: convertor
+
+convertor: $(OBJS)
+	$(CXX) -o convertor $(OBJS)
+
+FA.o: FA.h FA.cpp
+
+convertor.o: FA.o convertor.cpp
+
+clean:
+	$(RM) $(OBJS)
+
+distclean: clean
+	$(RM) tool

--- a/homework/NFA2DFA_auto_all_the_things/convertor.cpp
+++ b/homework/NFA2DFA_auto_all_the_things/convertor.cpp
@@ -1,0 +1,152 @@
+#include "FA.h"
+#include <map>
+#include <utility>
+#include <set>
+#include <stack>
+#include <iostream>
+
+/*epsilon_closure of T ( of FA ) is set of NFA states reachable from state T on
+  epsilon transition.  */
+auto
+epsilon_closure (fa::state t,
+		 const fa::finite_autometa &fa)
+{
+  auto fa_trans = fa.get_transition_relations ();
+  auto fa_states = fa.get_states ();
+
+  auto st = (std::stack <fa::state>) {};
+  st.push (t);
+
+  auto e_t = std::set({t});
+  while (!st.empty ())
+    {
+      auto top = st.top ();
+      st.pop ();
+
+      for (auto current_state: fa_states)
+	{
+	  if (fa.move (current_state, fa::epsilon).count (top)
+	      && !(e_t.count (current_state)))
+	    {
+	      e_t.insert (current_state);
+	      st.push (current_state);
+	    }
+	}
+    }
+
+  return e_t;
+}
+
+/*epsilon_closure of T ( of FA ) is set of NFA states reachable from set of
+  state T on epsilon transition.  */
+auto
+epsilon_closure (std::set <fa::state> t,
+		 const fa::finite_autometa &fa)
+{
+  auto fa_trans = fa.get_transition_relations ();
+  auto fa_states = fa.get_states ();
+
+  auto st = (std::stack <fa::state>) {};
+  for (auto s: t)
+    {
+      st.push (s);
+    }
+
+  auto e_t = t;
+  while (!st.empty ())
+    {
+      auto top = st.top ();
+      st.pop ();
+
+      for (auto current_state: fa_states)
+	{
+	  if (fa.move (current_state, fa::epsilon).count (top)
+	      && !(e_t.count (current_state)))
+	    {
+	      e_t.insert (current_state);
+	      st.push (current_state);
+	    }
+	}
+    }
+
+  return e_t;
+}
+
+/*The function take's non detereminisitic finite autometa (NAF) and returns a
+  deterministic finite autometa (DFA) that accepts the same language as NFA.  */
+auto
+convert (const fa::finite_autometa &nfa)
+{
+  auto s0 =  epsilon_closure (nfa.get_initialstate (),
+			      nfa);
+
+  /* the idea is that every dfa state is a set of nfa states.  */
+  using dfa_state = std::set <fa::state>;
+  auto dfa_states = std::set ({s0});
+
+  auto input_symbols = nfa.get_input_chars ();
+  std::map <std::pair <dfa_state, fa::symbol>,
+	    dfa_state> dfa_trans;
+
+  auto unmarked_states = dfa_states;
+
+  while (! unmarked_states.empty ())
+    {
+      auto T = unmarked_states.extract (unmarked_states.begin ());
+      for (auto symbol: input_symbols)
+	{
+	  auto u = epsilon_closure (nfa.move (T.value (),symbol), nfa);
+	  if (!dfa_states.count (u))
+	    {
+	      dfa_states.insert (u);
+	      unmarked_states.insert (u);
+	    }
+	  dfa_trans [{T.value (), symbol}] = u;
+	}
+    }
+  return dfa_trans;
+}
+
+auto main() -> int
+{
+  // TODO: add more tests
+  auto nfa_transitions = (fa::transition_table) { {{1,'a'},{1}} ,
+						  {{1,'b'},{2}} ,
+						  {{2,'a'},{2,1}} ,
+						  {{2,'b'},{3}} ,
+						  {{3,'a'},{3}} ,
+						  {{3,'b'},{3}}};
+  auto nfa = fa::finite_autometa ({1,2,3},
+				  {'a','b'},
+				  {3},
+				  1,
+				  nfa_transitions);
+  auto dfa_trans = convert(nfa);
+
+  /*Print this new transition table on stdout.  This is makeshift for now and
+   would be moved in seperate function or would be replaced by automated testing
+   of some kind in future versions.  */
+  for (const auto& tran : dfa_trans)
+    {
+      // states
+      std::cout <<"{ ";
+      for (auto state : tran.first.first)
+	{
+	  std::cout<<state<<" ";
+	}
+      std::cout<<"} / ";
+
+      //symbol scanned
+      std::cout<<tran.first.second<<" -> ";
+
+      // destination state
+      std::cout <<"{ ";
+      for (auto state : tran.second)
+	{
+	  std::cout<<state<<" ";
+	}
+      std::cout<<"}\n";
+    }
+
+  return 0;
+}


### PR DESCRIPTION
This is my attempt to create a project based on the philosophy of using [`auto`](https://en.cppreference.com/w/cpp/language/auto) for all the things. The project solely exists for experimental/learning purposes and for me to learn about advantages/disadvantages of using auto everywhere in a C++ project.

Critiques and/or suggestions to improve it are more than welcome.

P.S. I don't know if trailing return types qualifies as auto or not but it looked good here so I used it. :D

## What does the program do ?

The program is focussed on implementing `convert ()` function which simply converts a [NFA](https://en.wikipedia.org/wiki/Nondeterministic_finite_automaton) to [DFA](https://en.wikipedia.org/wiki/Deterministic_finite_automaton) using [subset construction method](https://en.wikipedia.org/wiki/Powerset_construction)